### PR TITLE
feature: makes title width depend on available space

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "main": "src/index.js",
   "exports": "./src/index.js",
   "type": "module",
+  "types": "types/compact-yarn-audit.d.ts",
   "scripts": {
     "format": "prettier --write src/**/*.js *.md",
     "scm:stage": "git add .",

--- a/src/__fixtures__/sample-output.wide-table.txt
+++ b/src/__fixtures__/sample-output.wide-table.txt
@@ -1,0 +1,23 @@
+severity  title                                           module                    via                       "resolutions" string
+critical  Command Injection                               destructomatic            vertex-cli                no fix available
+critical  Remote code execution when compiling templates  steering-wheel            beach-cruiser             "steering-wheel": ">=4.7.7"
+critical  Prototype Pollution                             steering-wheel            beach-cruiser             "steering-wheel": ">=4.0.14 <4.1.0 || >=4.1.2"
+high      Regular Expression Denial of Service            oedipus-regex             vertexql-validated-types  no fix available
+high      Command Injection                               snowdash                  beach-cruiser             "snowdash": ">=4.17.21"
+high      Prototype Pollution                             snowdash                  beach-cruiser             "snowdash": ">=4.17.12"
+high      Prototype Pollution                             snowdash                  beach-cruiser             "snowdash": ">=4.17.11"
+high      Command Injection                               snowdash                  .                         "snowdash": ">=4.17.21"
+high      Prototype Pollution                             snowdash                  .                         "snowdash": ">=4.17.12"
+high      Prototype Pollution                             snowdash                  .                         "snowdash": ">=4.17.11"
+high      Prototype Pollution                             steering-wheel            beach-cruiser             "steering-wheel": ">=3.0.8 <4.0.0 || >=4.5.3"
+high      Arbitrary Code Execution                        steering-wheel            beach-cruiser             "steering-wheel": ">=3.0.8 <4.0.0 || >=4.5.3"
+high      Arbitrary Code Execution                        steering-wheel            beach-cruiser             "steering-wheel": ">=3.0.8 <4.0.0 || >=4.5.2"
+high      Prototype Pollution                             steering-wheel            beach-cruiser             "steering-wheel": ">=3.0.8 <4.0.0 || >=4.3.0"
+moderate  Information Exposure                            apollo-server-core        saturnus-server-accident  "apollo-server-core": ">=2.14.2"
+moderate  Regular Expression Denial of Service            chestnut                  beach-cruiser             "chestnut": ">=5.7.4 <6.0.0 || >=6.4.1 <7.0.0 || >=7.1.1"
+moderate  Information Exposure                            saturnus-server-accident  .                         "saturnus-server-accident": ">=2.14.2"
+moderate  Denial of Service                               steering-wheel            beach-cruiser             "steering-wheel": ">=4.4.5"
+low       Prototype Pollution                             minifog                   beach-cruiser             "minifog": ">=0.2.1 <1.0.0 || >=1.2.3"
+low       Prototype Pollution                             snowdash                  beach-cruiser             "snowdash": ">=4.17.19"
+low       Prototype Pollution                             snowdash                  .                         "snowdash": ">=4.17.19"
+low       Prototype Pollution                             snowdash                  .                         "snowdash": ">=4.17.5"

--- a/src/terse-advisory-log.js
+++ b/src/terse-advisory-log.js
@@ -1,9 +1,19 @@
 import { createHash } from "node:crypto";
 
+/**
+ *
+ * @param {import("../types/compact-yarn-audit").ITerseEntry} pObject
+ * @returns {string}
+ */
 function hash(pObject) {
   return createHash("md5").update(JSON.stringify(pObject)).digest("base64");
 }
 
+/**
+ *
+ * @param {any} pLogEntry entry as emitted by yarn audit
+ * @returns {import("../types/compact-yarn-audit").ITerseEntry}
+ */
 function extractUsefulAttributes(pLogEntry) {
   const lFixable = pLogEntry.data.advisory.patched_versions !== "<0.0.0";
   const lVia = pLogEntry.data.resolution.path.split(">").shift();
@@ -19,6 +29,11 @@ function extractUsefulAttributes(pLogEntry) {
     via: lVia === pLogEntry.data.advisory.module_name ? "." : lVia,
   };
 }
+/**
+ *
+ * @param {import("../types/compact-yarn-audit").SeverityType} pSeverity
+ * @returns {number}
+ */
 function severity2Order(pSeverity) {
   const lSeverity2Order = {
     critical: 1,
@@ -30,10 +45,21 @@ function severity2Order(pSeverity) {
   return lSeverity2Order[pSeverity] || -1;
 }
 
+/**
+ *
+ * @param {import("../types/compact-yarn-audit").ITerseEntry} pEntry
+ * @returns {string}
+ */
 function getKey(pEntry) {
   return `${severity2Order(pEntry.severity)}|${pEntry.module_name}`;
 }
 
+/**
+ *
+ * @param {import("../types/compact-yarn-audit").ITerseEntry} pEntryLeft
+ * @param {import("../types/compact-yarn-audit").ITerseEntry} pEntryRight
+ * @returns {number}
+ */
 function orderEntry(pEntryLeft, pEntryRight) {
   return getKey(pEntryLeft) > getKey(pEntryRight) ? 1 : -1;
 }
@@ -49,13 +75,17 @@ export class TerseAdvisoryLog {
     if (pEntry.type === "auditAdvisory") {
       const lUsefulAttributes = extractUsefulAttributes(pEntry);
 
-      // Some auditlogs are several gigabytes long. Given that there'll
+      // Some audit logs are several gigabytes long. Given that there'll
       // be quite some duplicates, the overhead of the hash will be negligable
       // compared to the amount of memory that'd normally be needed
       this.log.set(hash(lUsefulAttributes), lUsefulAttributes);
     }
   }
 
+  /**
+   *
+   * @returns {import("../types/compact-yarn-audit").ITerseEntry[]}
+   */
   get() {
     return [...this.log.values()].sort(orderEntry);
   }

--- a/src/terse-object-to-table.spec.js
+++ b/src/terse-object-to-table.spec.js
@@ -18,7 +18,7 @@ describe("terse-object-to-table - smoke test", () => {
     chalk.level = chalkLevel;
   });
 
-  it("transforms a terse object to a table", () => {
+  it("transforms a terse object to a table (terminal has 125 columns available)", () => {
     expect(
       TerseAdvisoryLog2Table(
         JSON.parse(
@@ -26,11 +26,31 @@ describe("terse-object-to-table - smoke test", () => {
             join(__dirname, "__fixtures__", "sample-output.terselog.json"),
             "utf8"
           )
-        )
+        ),
+        125
       )
     ).to.deep.equal(
       readFileSync(
         join(__dirname, "__fixtures__", "sample-output.table.txt"),
+        "utf8"
+      )
+    );
+  });
+
+  it("transforms a terse object to a table (terminal has 1000 columns available)", () => {
+    expect(
+      TerseAdvisoryLog2Table(
+        JSON.parse(
+          readFileSync(
+            join(__dirname, "__fixtures__", "sample-output.terselog.json"),
+            "utf8"
+          )
+        ),
+        1000
+      )
+    ).to.deep.equal(
+      readFileSync(
+        join(__dirname, "__fixtures__", "sample-output.wide-table.txt"),
         "utf8"
       )
     );

--- a/types/compact-yarn-audit.d.ts
+++ b/types/compact-yarn-audit.d.ts
@@ -1,0 +1,9 @@
+export type SeverityType = "critical" | "high" | "moderate" | "low" | "info";
+export interface ITerseEntry {
+  severity: SeverityType;
+  title: string;
+  fixable: boolean;
+  fixString: string;
+  module_name: string;
+  via: string;
+}


### PR DESCRIPTION
## Description

- makes emitted title width depend on available space
- types the code base a bit
- uses String.substring instead of subset to truncate the titles

## Motivation and Context

- convenience

## How Has This Been Tested?

- [x] Green CI
- [x] Additional unit test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/compact-yarn-audit/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/compact-yarn-audit/blob/develop/.github/CONTRIBUTING.md).
