### PR TITLE
feature: makes output show 'no vulnerabilities found' when there's no vulnerabilities

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -1,0 +1,15 @@
+import { terseAdvisoryLog2Table } from "./terse-advisory-to-table.js";
+import { EOL } from "node:os";
+
+/**
+ *
+ * @param {import("../types/compact-yarn-audit.js").ITerseEntry[]} x
+ * @return {string}
+ */
+export default function format(pTerseEntries) {
+  if (pTerseEntries.length > 0) {
+    return terseAdvisoryLog2Table(pTerseEntries);
+  } else {
+    return `${EOL} no vulnerabilities found ${EOL}`;
+  }
+}

--- a/src/format.spec.js
+++ b/src/format.spec.js
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+import format from "./format.js";
+
+describe("format - smoke test", () => {
+  it("emits a message conveying there's no vulnerabilities when the # of terse entries === 0", () => {
+    expect(format([])).to.contain("no vulnerabilities found");
+  });
+
+  it("emits a table when the # of terse entries > 0", () => {
+    /** @type {import("../types/compact-yarn-audit").ITerseEntry[]} */
+    const lTerseEntries = [
+      {
+        severity: "critical",
+        title: "rotten fish is smelly",
+        module_name: "rotten-fish",
+        via: "fish-market",
+        fixable: true,
+        fixString: "buy fresh fish",
+      },
+    ];
+    expect(format(lTerseEntries)).to.contain("severity");
+    expect(format(lTerseEntries)).to.contain("title");
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import ndjson from "ndjson";
 import { TerseAdvisoryLog } from "./terse-advisory-log.js";
-import { TerseAdvisoryLog2Table } from "./terse-advisory-to-table.js";
+import format from "./format.js";
 
 const lAdvisaryLog = new TerseAdvisoryLog();
 
@@ -16,5 +16,5 @@ process.stdin
     process.exit();
   })
   .on("end", () => {
-    console.log(TerseAdvisoryLog2Table(lAdvisaryLog.get()));
+    console.log(format(lAdvisaryLog.get()));
   });

--- a/src/terse-advisory-to-table.js
+++ b/src/terse-advisory-to-table.js
@@ -40,7 +40,7 @@ function tableTheThing(pMaxTitleWidth) {
  * @param {import("../types/compact-yarn-audit").ITerseEntry[]} pTerseEntries
  * @returns {string}
  */
-export function TerseAdvisoryLog2Table(
+export function terseAdvisoryLog2Table(
   pTerseEntries,
   pColumnsAvailable = process.stdout.columns
 ) {

--- a/src/terse-object-to-table.spec.js
+++ b/src/terse-object-to-table.spec.js
@@ -3,7 +3,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { expect } from "chai";
 import chalk from "chalk";
-import { TerseAdvisoryLog2Table } from "../src/terse-advisory-to-table.js";
+import { terseAdvisoryLog2Table } from "../src/terse-advisory-to-table.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -20,7 +20,7 @@ describe("terse-object-to-table - smoke test", () => {
 
   it("transforms a terse object to a table (terminal has 125 columns available)", () => {
     expect(
-      TerseAdvisoryLog2Table(
+      terseAdvisoryLog2Table(
         JSON.parse(
           readFileSync(
             join(__dirname, "__fixtures__", "sample-output.terselog.json"),
@@ -39,7 +39,7 @@ describe("terse-object-to-table - smoke test", () => {
 
   it("transforms a terse object to a table (terminal has 1000 columns available)", () => {
     expect(
-      TerseAdvisoryLog2Table(
+      terseAdvisoryLog2Table(
         JSON.parse(
           readFileSync(
             join(__dirname, "__fixtures__", "sample-output.terselog.json"),


### PR DESCRIPTION
## Description

- makes output show 'no vulnerabilities found' when there's no vulnerabilities this instead of an empty table

## Motivation and Context

- is more clear this way

## How Has This Been Tested?

- [x] Green CI
- [x] Additional unit tests

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/compact-yarn-audit/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/compact-yarn-audit/blob/develop/.github/CONTRIBUTING.md).
