### PR TITLE
refactor(test): replaces chai with node:assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "5.36.1",
     "@typescript-eslint/parser": "5.36.1",
-    "chai": "4.3.6",
     "eslint": "8.23.0",
     "eslint-config-moving-meadow": "4.0.1",
     "eslint-config-prettier": "8.5.0",

--- a/src/format.spec.js
+++ b/src/format.spec.js
@@ -1,9 +1,9 @@
-import { expect } from "chai";
+import { match } from "node:assert";
 import format from "./format.js";
 
 describe("format - smoke test", () => {
   it("emits a message conveying there's no vulnerabilities when the # of terse entries === 0", () => {
-    expect(format([])).to.contain("no vulnerabilities found");
+    match(format([]), /no vulnerabilities found/);
   });
 
   it("emits a table when the # of terse entries > 0", () => {
@@ -18,7 +18,8 @@ describe("format - smoke test", () => {
         fixString: "buy fresh fish",
       },
     ];
-    expect(format(lTerseEntries)).to.contain("severity");
-    expect(format(lTerseEntries)).to.contain("title");
+
+    match(format(lTerseEntries), /severity/);
+    match(format(lTerseEntries), /title/);
   });
 });

--- a/src/terse-advisory-log.spec.js
+++ b/src/terse-advisory-log.spec.js
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { expect } from "chai";
+import { deepEqual } from "node:assert";
 import { TerseAdvisoryLog } from "./terse-advisory-log.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -21,7 +21,8 @@ describe("log-to-terse-object - smoke test", () => {
         lAdvisoryLog.add(pLogEntry);
       });
 
-    expect(lAdvisoryLog.get()).to.deep.equal(
+    deepEqual(
+      lAdvisoryLog.get(),
       JSON.parse(
         readFileSync(
           join(__dirname, "__fixtures__", "sample-output.terselog.json"),

--- a/src/terse-object-to-table.spec.js
+++ b/src/terse-object-to-table.spec.js
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { expect } from "chai";
+import { deepEqual } from "node:assert";
 import chalk from "chalk";
 import { terseAdvisoryLog2Table } from "./terse-advisory-to-table.js";
 
@@ -19,7 +19,7 @@ describe("terse-object-to-table - smoke test", () => {
   });
 
   it("transforms a terse object to a table (terminal has 125 columns available)", () => {
-    expect(
+    deepEqual(
       terseAdvisoryLog2Table(
         JSON.parse(
           readFileSync(
@@ -28,8 +28,7 @@ describe("terse-object-to-table - smoke test", () => {
           )
         ),
         125
-      )
-    ).to.deep.equal(
+      ),
       readFileSync(
         join(__dirname, "__fixtures__", "sample-output.table.txt"),
         "utf8"
@@ -38,7 +37,7 @@ describe("terse-object-to-table - smoke test", () => {
   });
 
   it("transforms a terse object to a table (terminal has 1000 columns available)", () => {
-    expect(
+    deepEqual(
       terseAdvisoryLog2Table(
         JSON.parse(
           readFileSync(
@@ -47,8 +46,7 @@ describe("terse-object-to-table - smoke test", () => {
           )
         ),
         1000
-      )
-    ).to.deep.equal(
+      ),
       readFileSync(
         join(__dirname, "__fixtures__", "sample-output.wide-table.txt"),
         "utf8"


### PR DESCRIPTION
## Description, Motivation and Context

Replaces chai expect/ assertion library with functions from node:assert, which ships with the node platform anyway. This way there's less external dependencies and less to maintain/ keep up to date.

## How Has This Been Tested?

- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/compact-yarn-audit/blob/main/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/compact-yarn-audit/blob/main/.github/CONTRIBUTING.md).
