### PR TITLE
refactor: uses set as internal datastructure

### DIFF
--- a/dist/terse-advisory-log.js
+++ b/dist/terse-advisory-log.js
@@ -1,7 +1,3 @@
-import { createHash } from "node:crypto";
-function hash(pEntry) {
-    return createHash("md5").update(JSON.stringify(pEntry)).digest("base64");
-}
 function extractUsefulAttributes(pLogEntry) {
     const lFixable = pLogEntry.data.advisory.patched_versions !== "<0.0.0";
     const lVia = pLogEntry.data.resolution.path.split(">").shift() ?? "?";
@@ -33,17 +29,19 @@ function orderEntry(pEntryLeft, pEntryRight) {
     return getKey(pEntryLeft) > getKey(pEntryRight) ? 1 : -1;
 }
 export class TerseAdvisoryLog {
-    log = new Map();
+    log = new Set();
     constructor() {
-        this.log = new Map();
+        this.log = new Set();
     }
     add(pEntry) {
         if (pEntry.type === "auditAdvisory") {
             const lUsefulAttributes = extractUsefulAttributes(pEntry);
-            this.log.set(hash(lUsefulAttributes), lUsefulAttributes);
+            this.log.add(JSON.stringify(lUsefulAttributes));
         }
     }
     get() {
-        return [...this.log.values()].sort(orderEntry);
+        return Array.from(this.log)
+            .map((pStringifiedEntry) => JSON.parse(pStringifiedEntry))
+            .sort(orderEntry);
     }
 }


### PR DESCRIPTION
## Description

- uses Set<stringified object> as internal datastructure (instead of a Map<md5(stringified object), object>)

## Motivation and Context

Both reduces complexity and memory footprint, which is a thing on large very outdated repos where the report might be humongous.

## How Has This Been Tested?

- [x] Green CI

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](https://github.com/sverweij/compact-yarn-audit/blob/develop/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](https://github.com/sverweij/compact-yarn-audit/blob/develop/.github/CONTRIBUTING.md).
